### PR TITLE
V15.1

### DIFF
--- a/lib/rspec_profiling/collectors/statsd.rb
+++ b/lib/rspec_profiling/collectors/statsd.rb
@@ -98,10 +98,6 @@ module RspecProfiling
         return str
       end
 
-      def format_date(date)
-        date.strftime(DATE_FORMAT_OUTPUT)
-      end
-
       def build_stamp(desc, line_number)
         readable_short = format_readable_short(desc)
         "#{line_number}_#{readable_short}"
@@ -135,7 +131,6 @@ module RspecProfiling
         stamp = build_stamp(attributes.fetch(:description), attributes.fetch(:line_number))
         path = format_file(attributes.fetch(:file), RspecProfiling.config.statsd_max_depth)
         branch = attributes.fetch(:branch)
-        commit_date = format_date(attributes.fetch(:date))
         key = "#{branch}.#{path}.#{stamp}".gsub("\n", '')
 
         self.statsd.batch do |b|

--- a/lib/rspec_profiling/collectors/statsd.rb
+++ b/lib/rspec_profiling/collectors/statsd.rb
@@ -6,11 +6,8 @@ require 'digest';
 module RspecProfiling
   module Collectors
     class Statsd
-      #delegate :timing, :increment, :count, :gauge, :time, :batch, to: :statsd, allow_nil: true 
       NAMESPACE = 'rspec_profiling'
 
-      DATE_FORMAT_INPUT = '%a %b %d %H:%M:%S %Y'
-      DATE_FORMAT_OUTPUT = '%Y%m%dT%H%M%S'
       #Property used by CSV Collector, leaving it here
       #to maintain reference of available properties.
       HEADERS = %w{
@@ -84,7 +81,7 @@ module RspecProfiling
         return @statsd unless @statsd.nil?
         self.health_check
         @statsd = ::Statsd.new(RspecProfiling.config.statsd_host, RspecProfiling.config.statsd_port, RspecProfiling.config.statsd_protocol).tap do |sd|
-          sd.namespace = "ldxe.#{NAMESPACE}.app"
+          sd.namespace = NAMESPACE
         end
       end
       
@@ -106,22 +103,8 @@ module RspecProfiling
       end
 
       def build_stamp(desc, line_number)
-        hash_desc = format_desc(desc)
         readable_short = format_readable_short(desc)
-        "#{line_number}_#{hash_desc}_#{readable_short}"
-      end
-
-      def format_readable_short(description) 
-        result = description.split(' ')
-        if result.length > 3
-          #Look for larger words to avoid prepositions and articles.
-          selected = result.select { |short| short.length > 3 }
-          #If this results in less than 3 words then use the original array.
-          selected = selected.length >= 3 ? selected : result
-          #Shorten to the last 3
-          result = shorten_array(selected, 3)
-        end
-        return result.join('_')
+        "#{line_number}_#{readable_short}"
       end
 
       def shorten_array(arr, max)
@@ -129,8 +112,8 @@ module RspecProfiling
         arr[-max..-1] 
       end
 
-      def format_readable_short(description) 
-        result = description.split(' ')
+      def format_readable_short(description)
+        result = description.gsub(/_|\\|\/|\./, ' ').split(' ')
         if result.length > 3
           #Look for larger words to avoid prepositions and articles.
           selected = result.select { |short| short.length > 3 }
@@ -150,10 +133,10 @@ module RspecProfiling
       def insert(attributes)
         hash = attributes.fetch(:commit_hash)[0..7]
         stamp = build_stamp(attributes.fetch(:description), attributes.fetch(:line_number))
-        path = format_file(attributes.fetch(:file))
+        path = format_file(attributes.fetch(:file), RspecProfiling.config.statsd_max_depth)
         branch = attributes.fetch(:branch)
         commit_date = format_date(attributes.fetch(:date))
-        key = "#{branch}.#{commit_date}_#{hash}.#{path}.#{stamp}".gsub("\n", '')
+        key = "#{branch}.#{path}.#{stamp}".gsub("\n", '')
 
         self.statsd.batch do |b|
           b.timing("#{key}.process_time", attributes.fetch(:time))

--- a/lib/rspec_profiling/version.rb
+++ b/lib/rspec_profiling/version.rb
@@ -1,3 +1,3 @@
 module RspecProfiling
-  VERSION = "0.0.14"
+  VERSION = "0.0.15"
 end

--- a/spec/collectors/statsd.rb
+++ b/spec/collectors/statsd.rb
@@ -33,17 +33,6 @@ module RspecProfiling
           expect(collector.results.count).to eq 1
         end
 
-        it 'Converts small description to 8 character hash' do
-          small = collector.format_desc('test')
-          expect(small.length).to eq(8)
-          expect(small).to eq('ccb19ba6')
-        end
-
-        it 'Converts large description to 8 character hash' do 
-          big = collector.format_desc('test more strings with spaces_and_underscores')
-          expect(big).to eq('a6bb61fe')
-        end
-
         it 'Converts file path to use dot separator over forward slash' do 
           str = collector.format_file('/spec/test/some_test.rb')
           expect(str).to eq 'test.some_test'
@@ -61,22 +50,22 @@ module RspecProfiling
         
         it 'Creates a readable stamp from a long string' do
           str = collector.build_stamp('API There are long strings in the test description where it can be really length however we need a small but unique name', 101)
-          expect(str).to eq '101_de72bdae_small_unique_name'
+          expect(str).to eq '101_small_unique_name'
         end
 
         it 'Creates a readable stamp from a single word' do
           str = collector.build_stamp('API', 101)
-          expect(str).to eq '101_0fbef1b4_API'
+          expect(str).to eq '101_API'
+        end
+
+        it 'Handles description with underscores and periods as part of the sentence' do
+          str = collector.build_stamp('There/be\\dragons. Who_don\'t_play_by_the_rules', 202)
+          expect(str).to eq '202_don\'t_play_rules'
         end
 
         it 'Creates a readable stamp from a three word sentence' do
           str = collector.build_stamp('There be dragons', 101)
-          expect(str).to eq '101_0de17114_There_be_dragons'
-        end
-
-        it 'Prefixes git commit hash with commit date' do
-          result = collector.results.first.description.match(/\d{8}T\d{6}/)
-          expect(result).not_to eq nil
+          expect(str).to eq '101_There_be_dragons'
         end
       end
     end


### PR DESCRIPTION
STAAS-8928:
- Removes commit hash and timestamp from high level stat directory.  This will enable all builds to use the same stat name, greatly reducing data consumption and enabling aggregation performed on a stat.
- Shortens namespace.
- Manages description names with underscores, slashes and periods better to avoid unintended hierarchy.